### PR TITLE
fix: exclude pnpm-lock.yaml from yamllint checks

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -5,6 +5,9 @@
 # https://yamllint.readthedocs.io/en/stable/configuration.html
 extends: default
 
+# Ignore specific files (regex). Exclude pnpm-lock.yaml from linting because it's a generated lockfile.
+ignore: '^pnpm-lock\.yaml$'
+
 yaml-files:
   - '*.yaml'
   - '*.yml'


### PR DESCRIPTION
This pull request makes several repository-wide updates, primarily rebranding all references from `boozt-platform/lefthook` to `yacosta738/lefthook` across documentation and configuration files. Additionally, it introduces Dependabot for GitHub Actions and updates YAML linting configuration. Below are the most important changes:

**Repository Rebranding:**

* Updated all documentation and configuration examples to reference `yacosta738/lefthook` instead of `boozt-platform/lefthook`, including in `README.md`, hook documentation, and example configuration files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R32) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R116) [[4]](diffhunk://#diff-d7768da1639c8dabf810c6eb907f450d024a59bdca4874c8a85fff1e167d72fbL12-R12) [[5]](diffhunk://#diff-f39801d70146ab4821a5db3a5c27690dff7ff0cb6799a67e908d2cbc68c9f112L11-R11) [[6]](diffhunk://#diff-d204291c840be8b689763d411752ece8914f6008a3a3a56348552de85f54a889L17-R17) [[7]](diffhunk://#diff-6b6e858026272367a19898b90141a924e43d598ff43cf4a41c64c7b85ee5bfe2L12-R12) [[8]](diffhunk://#diff-7ab58a436122a7263772f29c7bd192ecb6ece51c102d3c69dfb6e70ca251dda8L13-R13) [[9]](diffhunk://#diff-63905f9421e5fce174187828e4cc09a8efe7a98afcacb1d0d7321bcfd1cb69f7L10-R10) [[10]](diffhunk://#diff-01c4237c43c069b608216e9ac142254dd6e5b8567cb0b5288b2512065511b223L41-R41) [[11]](diffhunk://#diff-c401e81e59f2855f97aaebf0ecefd8557688df5eb1654a8b220a0bee541c019aL13-R13)

**Dependency Management:**

* Added a `.github/dependabot.yml` configuration to enable monthly updates for GitHub Actions dependencies, grouping all actions together.

**Linting Configuration:**

* Updated `.yamllint.yaml` to ignore `pnpm-lock.yaml`, since it's a generated lockfile, and clarified which YAML files to lint.[Copilot is generating a summary...]