### PR TITLE
fix: exclude additional lock and generated files from yamllint checks

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -5,8 +5,16 @@
 # https://yamllint.readthedocs.io/en/stable/configuration.html
 extends: default
 
-# Ignore specific files (regex). Exclude pnpm-lock.yaml from linting because it's a generated lockfile.
-ignore: '^pnpm-lock\.yaml$'
+# Ignore specific files (regex). Exclude lock files and generated files from linting.
+ignore: |
+  pnpm-lock.yaml
+  *.generated.yaml
+  *.generated.yml
+  **/node_modules/**
+  **/vendor/**
+  .git/**
+
+ignore-from-file: .gitignore
 
 yaml-files:
   - '*.yaml'


### PR DESCRIPTION
This pull request updates project metadata and documentation to reflect a new copyright holder and repository location. The changes ensure all references, legal notices, and documentation now point to Yuniel Acosta and the new GitHub repository.

**Licensing and Copyright**

* Updated copyright notices in all configuration, license, and script files to "Yuniel Acosta, CU" and updated the `LICENSE` file accordingly. [[1]](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2L1-R1) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L1-R1) [[3]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L1-R1) [[4]](diffhunk://#diff-00e49778078c450a994915211c89c6f0bc83c69d863552a988cec28ce885c1d3L1-R1) [[5]](diffhunk://#diff-da8ef5efa1ccda6d9b17188681178970430bccd3768cd4e9f584a673e05cdb17L3-R3) [[6]](diffhunk://#diff-635b64a6a0538aedd364795ef47d966775fd3424e1cd75fbff24068ada0b90caL3-R3) [[7]](diffhunk://#diff-43193187fb886808bb43bfb0c341e9f6fe14b86532cc5cf24fad3d879c7b2959L1-R1) [[8]](diffhunk://#diff-39aecbc26791dd03b9a4fdc1f856769ea73308294b7111d70f279ac9bdef35bdL1-R1) [[9]](diffhunk://#diff-6d64954d09d48e7ad2d33d6311f8e813c1dffdc4b4cad27b008a132f786eb9ccL1-R18) [[10]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3) [[11]](diffhunk://#diff-89ec6b4b24c366e9e639a80aecbd4c019e54b203d77badc4c63fb0dbc366bfeaL1-R1) [[12]](diffhunk://#diff-f67dff4c9f1dc7c70437fb87011f7fb7fe7dd21ee08e7ce52bb6ed456e0f1e68L1-R1) [[13]](diffhunk://#diff-6f986479d2677ed2244c38b55b62a733268a4003d762ec9e16fca8e11e53fe7fL1-R1) [[14]](diffhunk://#diff-906ae86b4d2135afb594363f73ff5aa340dabcb094870438248671552c05791cL1-R1) [[15]](diffhunk://#diff-4c6b93aa75d5affde60dc3849606c9acd75ed444d52e99f3055fc0c7aa77e9e0L110-R110) [[16]](diffhunk://#diff-4c6b93aa75d5affde60dc3849606c9acd75ed444d52e99f3055fc0c7aa77e9e0L155-R155)

**Repository and Documentation Updates**

* Changed all repository URLs and references in `README.md`, documentation, and example configuration files from `boozt-platform/lefthook` to `yacosta738/lefthook`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R33) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R116) [[4]](diffhunk://#diff-d7768da1639c8dabf810c6eb907f450d024a59bdca4874c8a85fff1e167d72fbL12-R12) [[5]](diffhunk://#diff-f39801d70146ab4821a5db3a5c27690dff7ff0cb6799a67e908d2cbc68c9f112L11-R11) [[6]](diffhunk://#diff-d204291c840be8b689763d411752ece8914f6008a3a3a56348552de85f54a889L17-R17)

**Configuration Improvements**

* Added a new `.github/dependabot.yml` to enable monthly GitHub Actions dependency updates.
* Enhanced `.yamllint.yaml` with ignore patterns and support for `.gitignore` to exclude lock, generated, and vendor files from linting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated YAML lint configuration to ignore common artifacts and folders, including pnpm-lock.yaml, *.generated.{yaml,yml}, **/node_modules/**, **/vendor/**, and .git/**.
  * Config now also respects ignore rules from .gitignore for consistent exclusions across tools.
  * Expanded lint target files to include *.yml, .yamllint, and .yamllint.yaml in addition to *.yaml, improving consistency and coverage of YAML linting across the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->